### PR TITLE
fix: increase gunicorn timeout to 60s

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:gunicorn]
 directory=/usr/src/package/
-command=gunicorn swagger_server.__main__:app -b 0.0.0.0:8000
+command=gunicorn --timeout 60 swagger_server.__main__:app -b 0.0.0.0:8000
 autostart=true
 autorestart=true
 startsecs=10


### PR DESCRIPTION
Similar issue to https://github.com/registreerocks/query-db-api/pull/51/files.

Encountered this issue when trying to run the send bulk email jupyter notebook.

```
root@demo:~/backend-demo# docker ps
CONTAINER ID        IMAGE                                 COMMAND                  CREATED             STATUS              PORTS                            NAMES
d2abd056e308        nginx:latest                          "/docker-entrypoint.…"   4 months ago        Up 4 months         80/tcp, 0.0.0.0:2053->2053/tcp   production_nginx_API_Aggregator
41029efb5c1f        registree/query-db-api:latest         "/usr/bin/supervisord"   4 months ago        Up 4 months                                          query_db_api
d70ecbcc166d        registree/student-nft-api:latest      "/usr/bin/supervisord"   4 months ago        Up 4 months                                          student_nft_api
28b1afc0b838        registree/customer-db-api:latest      "/usr/bin/supervisord"   4 months ago        Up 4 months                                          customer_db_api
4977ff66cd8f        registree/identifying-db-api:latest   "/usr/bin/supervisord"   4 months ago        Up 4 months                                          identifying_db_api
ab819ae87ca3        registree/student-db-api:latest       "/usr/bin/supervisord"   4 months ago        Up 4 months                                          student_db_api
8292c8a27a45        mongo:3.6                             "docker-entrypoint.s…"   4 months ago        Up 4 months         0.0.0.0:27017->27017/tcp         backend-demo_mongodb_1
root@demo:~/backend-demo# docker exec -it d70ecbcc166d bash
root@d70ecbcc166d:/usr/src/package# ls
setup.py  src  test
root@d70ecbcc166d:/usr/src/package# cd src/
root@d70ecbcc166d:/usr/src/package/src# ls
__init__.py  __pycache__  studentNFT_API.egg-info  swagger_server
root@d70ecbcc166d:/usr/src/package/src# cat swagger_server/
cat: swagger_server/: Is a directory
root@d70ecbcc166d:/usr/src/package/src# cd swagger_server/
root@d70ecbcc166d:/usr/src/package/src/swagger_server# ls
__init__.py  __main__.py  __pycache__  controllers  swagger
root@d70ecbcc166d:/usr/src/package/src/swagger_server# cd ../../
root@d70ecbcc166d:/usr/src/package# cd /var/logs/
bash: cd: /var/logs/: No such file or directory
root@d70ecbcc166d:/usr/src/package# ls
setup.py  src  test
root@d70ecbcc166d:/usr/src/package# cd /var/log
root@d70ecbcc166d:/var/log# ls
alternatives.log  apt  btmp  dpkg.log  faillog	flask.log  fontconfig.log  lastlog  supervisor	wtmp
root@d70ecbcc166d:/var/log# cd supervisor/
root@d70ecbcc166d:/var/log/supervisor# ls
gunicorn-stderr---supervisor-kgn_Bw.log  supervisord.log
root@d70ecbcc166d:/var/log/supervisor# cat uni^C
root@d70ecbcc166d:/var/log/supervisor# cat gunicorn-stderr---supervisor-kgn_Bw.log
[2023-04-20 07:30:15 +0000] [8] [INFO] Starting gunicorn 20.0.4
[2023-04-20 07:30:15 +0000] [8] [INFO] Listening at: http://0.0.0.0:8000/ (8)
[2023-04-20 07:30:15 +0000] [8] [INFO] Using worker: sync
[2023-04-20 07:30:15 +0000] [11] [INFO] Booting worker with pid: 11
[2023-08-23 11:31:54 +0000] [8] [CRITICAL] WORKER TIMEOUT (pid:11)
[2023-08-23 11:31:55 +0000] [38] [INFO] Booting worker with pid: 38
```

```
2023/08/23 11:31:55 [error] 28#28: *9682973 upstream prematurely closed connection while reading response header from upstream, client: 172.71.246.39, server: _, request: "POST /studentnft/student/bulk_get_identifying_id HTTP/1.1", upstream: "http://172.29.0.4:8000/student/bulk_get_identifying_id", host: "demoapi.registree.io:2053"
```